### PR TITLE
Potential fix for code scanning alert no. 4: Double escaping or unescaping

### DIFF
--- a/src/app/api/games/route.ts
+++ b/src/app/api/games/route.ts
@@ -24,8 +24,8 @@ const BACKLOG_REGEX = /href="\/u\/[^/]+\/backlog\/[^"]*"[^>]*>\s*<h\d+>\s*([0-9,
 function cleanGameTitle(raw: string): string {
 	return raw
 		.replaceAll('&#39;', "'")
-		.replaceAll('&amp;', '&')
 		.replaceAll('&quot;', '"')
+		.replaceAll('&amp;', '&')
 		.trim();
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/Noahffiliation/hobby-stats/security/code-scanning/4](https://github.com/Noahffiliation/hobby-stats/security/code-scanning/4)

To fix this safely without changing intended functionality, decode `&amp;` **last** in `cleanGameTitle`.  
In `src/app/api/games/route.ts`, update the replacement chain so specific entities (`&#39;`, `&quot;`) are decoded first, and `&amp;` is decoded last.

Best minimal fix in-place:
- Keep the same method and behavior.
- Reorder the chained replacements:
  - `&#39;` → `'`
  - `&quot;` → `"`
  - `&amp;` → `&` (last)
- Keep `.trim()` unchanged.

No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
