### PR TITLE
Potential fix for code scanning alert no. 3: Double escaping or unescaping

### DIFF
--- a/src/app/api/dramas/route.ts
+++ b/src/app/api/dramas/route.ts
@@ -22,11 +22,11 @@ export interface DramaListResponse {
 
 function decodeHtmlEntities(str: string): string {
 	return str
-		.replaceAll('&amp;', '&')
 		.replaceAll('&lt;', '<')
 		.replaceAll('&gt;', '>')
 		.replaceAll('&quot;', '"')
-		.replaceAll('&#39;', "'");
+		.replaceAll('&#39;', "'")
+		.replaceAll('&amp;', '&');
 }
 
 export function parseSingleDramaRow(rowHtml: string): DramaItem | null {


### PR DESCRIPTION
Potential fix for [https://github.com/Noahffiliation/hobby-stats/security/code-scanning/3](https://github.com/Noahffiliation/hobby-stats/security/code-scanning/3)

To fix this without changing intended functionality, reorder entity replacements in `decodeHtmlEntities` so `&amp;` is decoded **last**. Keep all existing replacements and behavior otherwise unchanged.

Specifically in `src/app/api/dramas/route.ts`, update `decodeHtmlEntities`:
- Move `.replaceAll('&amp;', '&')` from first position to last.
- Keep `&lt;`, `&gt;`, `&quot;`, and `&#39;` decoding before it.

No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
